### PR TITLE
Enable zero value assets

### DIFF
--- a/packages/nextjs/components/Processes/BundlingProcess/Steps/AssetSelectionStep/ManualAssetSelection/ManualAssetSelection.tsx
+++ b/packages/nextjs/components/Processes/BundlingProcess/Steps/AssetSelectionStep/ManualAssetSelection/ManualAssetSelection.tsx
@@ -7,6 +7,7 @@ import { motion } from "framer-motion";
 import { createPortal } from "react-dom";
 import { Tabs } from "~~/components/tabs/Tabs";
 import { IWrappedRecoveryTx } from "~~/hooks/flashbotRecoveryBundle/useAutodetectAssets";
+import { RawFlow } from "./RawFlow/RawFlow";
 
 interface IProps {
   isVisible: boolean;
@@ -35,13 +36,15 @@ export const ManualAssetSelection = ({ isVisible, close, safeAddress, addAsset, 
         </span>
         <div className={`${styles.modalContent}`}>
           <h3 className={`${styles.title}`}>{"Add assets manually"}</h3>
-          <Tabs tabTitles={["Basic", "Custom"]}>
+          <Tabs tabTitles={["Basic", "Custom", "Raw"]}>
             {active => {
               const isBasic = active == 0;
               if (isBasic) {
                 return <BasicFlow safeAddress={safeAddress} hackedAddress={hackedAddress} addAsset={addAsset} />;
+              } else if (active == 1) {
+                return <CustomFlow hackedAddress={hackedAddress} addAsset={item => addAsset(item)} />;
               }
-              return <CustomFlow hackedAddress={hackedAddress} addAsset={item => addAsset(item)} />;
+              return <RawFlow hackedAddress={hackedAddress} addAsset={item => addAsset(item)} />;
             }}
           </Tabs>
         </div>

--- a/packages/nextjs/components/Processes/BundlingProcess/Steps/AssetSelectionStep/ManualAssetSelection/RawFlow/RawFlow.tsx
+++ b/packages/nextjs/components/Processes/BundlingProcess/Steps/AssetSelectionStep/ManualAssetSelection/RawFlow/RawFlow.tsx
@@ -1,0 +1,57 @@
+import { useState } from "react";
+import styles from "../manualAssetSelection.module.css";
+import { parseTransaction } from "viem";
+import { CustomButton } from "~~/components/CustomButton/CustomButton";
+import { InputBase } from "~~/components/scaffold-eth";
+import { IWrappedRecoveryTx } from "~~/hooks/flashbotRecoveryBundle/useAutodetectAssets";
+import { CustomTx } from "~~/types/business";
+
+interface IRawFlowProps {
+  hackedAddress: string;
+  addAsset: (asset: IWrappedRecoveryTx) => void;
+}
+export const RawFlow = ({ hackedAddress, addAsset }: IRawFlowProps) => {
+  const [rawTx, setRawTx] = useState<string>("");
+  const addRawTxToBasket = () => {
+    const parsedTx = parseTransaction(rawTx as `0x${string}`);
+    console.log(parsedTx);
+    const { to, value, data = "0x" } = parsedTx;
+    const customTx: CustomTx = {
+      type: "custom",
+      info: `Raw Transaction ${rawTx.substring(0, 40)}...`,
+      toEstimate: {
+        from: hackedAddress as `0x${string}`,
+        to: to as `0x${string}`,
+        value: value ? value.toString() : "0",
+        data: (data as `0x${string}`) || "0x",
+      },
+    };
+    addAsset({ tx: customTx });
+  };
+
+  const checkValid = () => {
+    try {
+      const parsed = parseTransaction(rawTx as `0x${string}`);
+      if (parsed) {
+        return true;
+      }
+    } catch (e) {
+      return false;
+    }
+    return false;
+  };
+  return (
+    <>
+      <div className="mt-10" />
+      <div className={styles.containerCustom}>
+        <div className="mt-6" />
+        <label className={styles.label} htmlFor="rawTx">
+          Raw Transaction
+        </label>
+        <InputBase name="rawTx" value={rawTx as `0x{string}`} placeholder="0x02ef01820..." onChange={setRawTx} />
+        <div className="mt-6" />
+        <CustomButton type="btn-primary" text={"Add"} disabled={!checkValid()} onClick={() => addRawTxToBasket()} />
+      </div>
+    </>
+  );
+};

--- a/packages/nextjs/hooks/flashbotRecoveryBundle/useAutodetectAssets.ts
+++ b/packages/nextjs/hooks/flashbotRecoveryBundle/useAutodetectAssets.ts
@@ -53,12 +53,12 @@ export const useAutodetectAssets = () => {
       await Promise.all([
         alchemy.core.getAssetTransfers({
           fromAddress: hackedAddress,
-          excludeZeroValue: true,
+          excludeZeroValue: false,
           category: [AssetTransfersCategory.ERC20, AssetTransfersCategory.ERC721, AssetTransfersCategory.ERC1155],
         }),
         alchemy.core.getAssetTransfers({
           toAddress: hackedAddress,
-          excludeZeroValue: true,
+          excludeZeroValue: false,
           category: [AssetTransfersCategory.ERC20, AssetTransfersCategory.ERC721, AssetTransfersCategory.ERC1155],
         }),
       ])

--- a/packages/nextjs/hooks/flashbotRecoveryBundle/useAutodetectAssets.ts
+++ b/packages/nextjs/hooks/flashbotRecoveryBundle/useAutodetectAssets.ts
@@ -54,12 +54,12 @@ export const useAutodetectAssets = () => {
         alchemy.core.getAssetTransfers({
           fromAddress: hackedAddress,
           excludeZeroValue: false,
-          category: [AssetTransfersCategory.ERC20, AssetTransfersCategory.ERC721, AssetTransfersCategory.ERC1155],
+          category: [AssetTransfersCategory.ERC20, AssetTransfersCategory.ERC721, AssetTransfersCategory.ERC1155, AssetTransfersCategory.INTERNAL],
         }),
         alchemy.core.getAssetTransfers({
           toAddress: hackedAddress,
           excludeZeroValue: false,
-          category: [AssetTransfersCategory.ERC20, AssetTransfersCategory.ERC721, AssetTransfersCategory.ERC1155],
+          category: [AssetTransfersCategory.ERC20, AssetTransfersCategory.ERC721, AssetTransfersCategory.ERC1155, AssetTransfersCategory.INTERNAL],
         }),
       ])
     )
@@ -108,6 +108,8 @@ export const useAutodetectAssets = () => {
           erc721transfers.push(tx);
         } else if (tx.category == AssetTransfersCategory.ERC1155) {
           erc1155transfers.push(tx);
+        } else if (tx.category == AssetTransfersCategory.INTERNAL) {
+          console.log("Internal tx detected. Ignoring.", tx);
         }
       });
 

--- a/packages/nextjs/hooks/flashbotRecoveryBundle/useAutodetectAssets.ts
+++ b/packages/nextjs/hooks/flashbotRecoveryBundle/useAutodetectAssets.ts
@@ -53,13 +53,13 @@ export const useAutodetectAssets = () => {
       await Promise.all([
         alchemy.core.getAssetTransfers({
           fromAddress: hackedAddress,
-          excludeZeroValue: false,
-          category: [AssetTransfersCategory.ERC20, AssetTransfersCategory.ERC721, AssetTransfersCategory.ERC1155, AssetTransfersCategory.EXTERNAL, AssetTransfersCategory.INTERNAL],
+          excludeZeroValue: true,
+          category: [AssetTransfersCategory.ERC20, AssetTransfersCategory.ERC721, AssetTransfersCategory.ERC1155],
         }),
         alchemy.core.getAssetTransfers({
           toAddress: hackedAddress,
-          excludeZeroValue: false,
-          category: [AssetTransfersCategory.ERC20, AssetTransfersCategory.ERC721, AssetTransfersCategory.ERC1155, AssetTransfersCategory.EXTERNAL, AssetTransfersCategory.INTERNAL],
+          excludeZeroValue: true,
+          category: [AssetTransfersCategory.ERC20, AssetTransfersCategory.ERC721, AssetTransfersCategory.ERC1155],
         }),
       ])
     )
@@ -108,8 +108,6 @@ export const useAutodetectAssets = () => {
           erc721transfers.push(tx);
         } else if (tx.category == AssetTransfersCategory.ERC1155) {
           erc1155transfers.push(tx);
-        } else {
-          console.log(`Unknown asset transfer category: ${tx.category}`, tx);
         }
       });
 

--- a/packages/nextjs/types/business.d.ts
+++ b/packages/nextjs/types/business.d.ts
@@ -4,6 +4,7 @@ export interface CoreTxToEstimate {
   from: `0x${string}`;
   to: `0x${string}`;
   data: `0x${string}`;
+  value?: string | bigint;
 }
 
 export interface CoreTxToSign extends CoreTxToEstimate {


### PR DESCRIPTION
Currently we are blocking all zero value assets from showing in the wallet. This may be in an attempt to cut down on spam but I think we should reconsider because most of the assets people try to recover are of little value or else they would have been sweeped.