### PR TITLE
[Bug Fix] use BigInt to parse hex strings

### DIFF
--- a/packages/nextjs/hooks/flashbotRecoveryBundle/useAutodetectAssets.ts
+++ b/packages/nextjs/hooks/flashbotRecoveryBundle/useAutodetectAssets.ts
@@ -302,7 +302,7 @@ export const useAutodetectAssets = () => {
 
             const result: NftMetadataBatchToken[] = ownedTokenIds.map(tokenId => ({
               contractAddress: erc721contract as `0x${string}`,
-              tokenId: parseInt(tokenId).toString(),
+              tokenId: BigInt(tokenId).toString(),
               tokenType: NftTokenType.ERC721,
             }));
             erc721Minimal.push(...result);
@@ -312,7 +312,7 @@ export const useAutodetectAssets = () => {
                 type: "erc721",
                 info: `ERC721 - ${tokenSymbol != "???" ? `${tokenSymbol}` : `${erc721contract}`}`,
                 symbol: tokenSymbol,
-                tokenId: parseInt(tokenId).toString(),
+                tokenId: BigInt(tokenId).toString(),
                 toEstimate: {
                   from: hackedAddress as `0x${string}`,
                   to: erc721contract as `0x${string}`,


### PR DESCRIPTION
There was a couple places where we were using parseInt to go from a hex string to a decimal number for tokenIds. This worked fine unless the number was too large which is the case with all ENS name tokenIds. This uses BigInt instead to convert the hex a decimal number string.

![image](https://github.com/BuidlGuidl/flashbot-recovery-bundler/assets/22101475/0b03b489-95fe-4138-bc23-65bb4d25c5c4)
