### PR TITLE
Secondary Alchemy key

### DIFF
--- a/packages/nextjs/hooks/flashbotRecoveryBundle/useRecoveryProcess.ts
+++ b/packages/nextjs/hooks/flashbotRecoveryBundle/useRecoveryProcess.ts
@@ -50,7 +50,10 @@ export const useRecoveryProcess = () => {
   useEffect(() => {
     (async () => {
       if (!targetNetwork || !targetNetwork.blockExplorers) return;
-      const mainnetProvider = new ethers.providers.AlchemyProvider(targetNetwork.id, scaffoldConfig.alchemyApiKey);
+      const mainnetProvider = new ethers.providers.AlchemyProvider(
+        targetNetwork.id,
+        scaffoldConfig.alchemyApiKey2 || scaffoldConfig.alchemyApiKey,
+      );
       setMainnetProvider(mainnetProvider);
       setFlashbotsProvider(
         await FlashbotsBundleProvider.create(

--- a/packages/nextjs/scaffold.config.ts
+++ b/packages/nextjs/scaffold.config.ts
@@ -4,6 +4,7 @@ export type ScaffoldConfig = {
   targetNetwork: chains.Chain;
   pollingInterval: number;
   alchemyApiKey: string;
+  alchemyApiKey2: string;
   walletConnectProjectId: string;
   onlyLocalBurnerWallet: boolean;
   walletAutoConnect: boolean;
@@ -22,6 +23,9 @@ const scaffoldConfig = {
   // It's recommended to store it in an env variable:
   // .env.local for local testing, and in the Vercel/system env config for live apps.
   alchemyApiKey: process.env.NEXT_PUBLIC_ALCHEMY_API_KEY || "oKxs-03sij-U_N0iOlrSsZFr29-IqbuF",
+
+  // Extra Alchemy key for handling lower tier requests (blockheight, etc)
+  alchemyApiKey2: process.env.NEXT_PUBLIC_ALCHEMY_API_KEY_2 || "oKxs-03sij-U_N0iOlrSsZFr29-IqbuF",
 
   // This is ours WalletConnect's default project ID.
   // You can get your own at https://cloud.walletconnect.com


### PR DESCRIPTION
Adding a secondary Alchemy key to handle the block height requests so that we don't use all our high tier credits on low tier requests.

Closes https://github.com/BuidlGuidl/flashbot-recovery-bundler/issues/45