### PR TITLE
Make ens names stand out

### DIFF
--- a/packages/nextjs/components/scaffold-eth/Input/AddressInput.tsx
+++ b/packages/nextjs/components/scaffold-eth/Input/AddressInput.tsx
@@ -61,12 +61,12 @@ export const AddressInput = ({ value, name, placeholder, onChange }: CommonInput
       disabled={isEnsAddressLoading || isEnsNameLoading}
       prefix={
         ensName && (
-          <div className="flex bg-base-300 rounded-l-full items-center">
+          <div className="flex bg-[#7197d9] items-center">
             {ensAvatar ? (
               <span className="w-[35px]">
                 {
                   // eslint-disable-next-line
-                  <img className="w-full rounded-full" src={ensAvatar} alt={`${ensAddress} avatar`} />
+                  <img className="w-full" src={ensAvatar} alt={`${ensAddress} avatar`} />
                 }
               </span>
             ) : null}
@@ -74,7 +74,7 @@ export const AddressInput = ({ value, name, placeholder, onChange }: CommonInput
           </div>
         )
       }
-      suffix={value && <Blockies className="!rounded-full" seed={value?.toLowerCase() as string} size={7} scale={5} />}
+      suffix={value && <Blockies seed={value?.toLowerCase() as string} size={7} scale={5} />}
     />
   );
 };

--- a/packages/nextjs/components/scaffold-eth/Input/AddressInput.tsx
+++ b/packages/nextjs/components/scaffold-eth/Input/AddressInput.tsx
@@ -61,12 +61,12 @@ export const AddressInput = ({ value, name, placeholder, onChange }: CommonInput
       disabled={isEnsAddressLoading || isEnsNameLoading}
       prefix={
         ensName && (
-          <div className="flex bg-[#7197d9] items-center">
+          <div className="flex bg-[#7197d9] rounded-l-full items-center">
             {ensAvatar ? (
               <span className="w-[35px]">
                 {
                   // eslint-disable-next-line
-                  <img className="w-full" src={ensAvatar} alt={`${ensAddress} avatar`} />
+                  <img className="w-full rounded-full" src={ensAvatar} alt={`${ensAddress} avatar`} />
                 }
               </span>
             ) : null}
@@ -74,7 +74,7 @@ export const AddressInput = ({ value, name, placeholder, onChange }: CommonInput
           </div>
         )
       }
-      suffix={value && <Blockies seed={value?.toLowerCase() as string} size={7} scale={5} />}
+      suffix={value && <Blockies className="!rounded-full" seed={value?.toLowerCase() as string} size={7} scale={5} />}
     />
   );
 };

--- a/packages/nextjs/components/scaffold-eth/Input/InputBase.tsx
+++ b/packages/nextjs/components/scaffold-eth/Input/InputBase.tsx
@@ -33,17 +33,17 @@ export const InputBase = <T extends { toString: () => string } | undefined = str
   );
 
   return (
-    <div className={`flex border-2 border-base-300 bg-base-200 rounded-full text-accent ${modifier}`}>
+    <div className={`flex border-2 border-base-300 bg-base-200 !rounded-full text-accent ${modifier}`}>
       {prefix}
       <input
-        className="input input-ghost focus:outline-none focus:bg-transparent focus:text-gray-400 h-[2.2rem] min-h-[2.2rem] px-4 border w-full font-medium text-gray-400 placeholder-gray-200 placeholder-opacity-10"
+        className="input input-ghost focus:outline-none !rounded-full focus:bg-transparent focus:text-gray-400 h-[2.2rem] min-h-[2.2rem] px-4 border w-full font-medium text-gray-400 placeholder-gray-200 placeholder-opacity-10"
         placeholder={placeholder}
         name={name}
         value={value?.toString()}
         onChange={handleChange}
         disabled={disabled}
         autoComplete="off"
-        style={{background: "#243148"}}
+        style={{ background: "#243148" }}
       />
       {suffix}
     </div>


### PR DESCRIPTION
Fixes #48 

## This PR
-> Uses a custom color for the ens name bg
-> Makes ens name bg + blockies square because the input is square as well 

I think we should make the whole app square or rounded, lmk what you think about this, converting to draft to discuss this more.


I am more in favor of everything being rounded I guess, since logo and every other element is also rounded


Before(left) and after:
![image](https://github.com/user-attachments/assets/3903f63c-9a4a-47e3-8a4f-9d488b3f6733)



Everything rounded version:
![image](https://github.com/user-attachments/assets/7f1f8ada-4565-4267-9de3-3d99e3da7932)

