### PR TITLE
Use different decimals for USDC USDT WBTC

### DIFF
--- a/packages/nextjs/components/Processes/BundlingProcess/Steps/AssetSelectionStep/AutoDetectedAssets/AutoDetectedAssetItem.tsx
+++ b/packages/nextjs/components/Processes/BundlingProcess/Steps/AssetSelectionStep/AutoDetectedAssets/AutoDetectedAssetItem.tsx
@@ -3,6 +3,7 @@ import EmptySvg from "../../../../../../public/assets/flashbotRecovery/empty.svg
 import TransactionsSvg from "../../../../../../public/assets/flashbotRecovery/transactions.svg";
 import styles from "./autoDetectedAssets.module.css";
 import { motion } from "framer-motion";
+import { formatUnits } from "viem";
 import { Address } from "~~/components/scaffold-eth";
 import { RecoveryTx } from "~~/types/business";
 import { extractAbiNinjaCallDetails, formatCalldataString } from "~~/utils/abiNinjaFlowUtils";
@@ -27,8 +28,17 @@ export const AutoDetectedAssetItem = ({ onClick, isSelected, tx, isLoading, imag
       // @ts-ignore
       subtitleContent = `Token IDs: ${tx.tokenIds.map(hexId => BigInt(hexId).toString()).join(", ")}`;
     } else if (tx.type === "erc20") {
+      const decimals =
+        (
+          {
+            USDC: 6,
+            USDT: 6,
+            WBTC: 8,
+          } as Record<string, number>
+        )[(tx as { symbol: string }).symbol] ?? 18;
       // @ts-ignore
-      subtitleContent = tx.amount;
+      const formattedAmount = formatUnits(tx.amount, decimals);
+      subtitleContent = formattedAmount;
     } else if (tx.type === "custom") {
       subtitleContent = tx.info.split(" to ")[1];
     } else if (tx.type === "custom-abininja") {

--- a/packages/nextjs/components/Processes/BundlingProcess/Steps/AssetSelectionStep/AutoDetectedAssets/AutoDetectedAssetItem.tsx
+++ b/packages/nextjs/components/Processes/BundlingProcess/Steps/AssetSelectionStep/AutoDetectedAssets/AutoDetectedAssetItem.tsx
@@ -28,16 +28,8 @@ export const AutoDetectedAssetItem = ({ onClick, isSelected, tx, isLoading, imag
       // @ts-ignore
       subtitleContent = `Token IDs: ${tx.tokenIds.map(hexId => BigInt(hexId).toString()).join(", ")}`;
     } else if (tx.type === "erc20") {
-      const decimals =
-        (
-          {
-            USDC: 6,
-            USDT: 6,
-            WBTC: 8,
-          } as Record<string, number>
-        )[(tx as { symbol: string }).symbol] ?? 18;
       // @ts-ignore
-      const formattedAmount = formatUnits(tx.amount, decimals);
+      const formattedAmount = formatUnits(tx.amount, tx.decimals);
       subtitleContent = formattedAmount;
     } else if (tx.type === "custom") {
       subtitleContent = tx.info.split(" to ")[1];

--- a/packages/nextjs/hooks/flashbotRecoveryBundle/useAutodetectAssets.ts
+++ b/packages/nextjs/hooks/flashbotRecoveryBundle/useAutodetectAssets.ts
@@ -99,7 +99,7 @@ export const useAutodetectAssets = () => {
       erc721transfers: AssetTransfersResult[] = [],
       erc1155transfers: AssetTransfersResult[] = [],
       erc1155Minimal: NftMetadataBatchToken[] = [],
-      erc721Minimal: NftMetadataBatchToken[] = []
+      erc721Minimal: NftMetadataBatchToken[] = [];
     try {
       (await fetchAllAssetTransfersOfHackedAccount(hackedAddress)).forEach(tx => {
         if (tx.category == AssetTransfersCategory.ERC20) {
@@ -267,6 +267,15 @@ export const useAutodetectAssets = () => {
             /* ignore */
           }
 
+          // Find the transfer that matches this contract to get decimals
+          const relevantTransfer = erc20transfers.find(
+            tx => tx.rawContract?.address?.toLowerCase() === erc20contract.toLowerCase(),
+          );
+
+          const decimals = relevantTransfer?.rawContract?.decimal
+            ? parseInt(relevantTransfer.rawContract.decimal, 16)
+            : 18;
+
           const newErc20tx: ERC20Tx = {
             type: "erc20",
             info: `ERC20 - ${tokenSymbol != "???" ? `${tokenSymbol}` : `${erc20contract}`}`,
@@ -280,6 +289,7 @@ export const useAutodetectAssets = () => {
                 BigNumber.from(erc20balance),
               ]) as `0x${string}`,
             },
+            decimals,
           };
           return newErc20tx;
         }),

--- a/packages/nextjs/types/business.d.ts
+++ b/packages/nextjs/types/business.d.ts
@@ -26,6 +26,7 @@ export interface CustomTx extends ExtendedUnsignedTx {}
 export interface ERC20Tx extends ExtendedUnsignedTx {
   symbol: string;
   amount: string;
+  decimals: number;
 }
 
 export interface ERC721Tx extends ExtendedUnsignedTx {


### PR DESCRIPTION
Use decimals:
USDC: 6,
USDT: 6,
WBTC: 8, 
instead of the usual 18, which shows USDC balance wrongly