### PR TITLE
Send funds to safeAddress instead of connected address

### DIFF
--- a/packages/nextjs/hooks/flashbotRecoveryBundle/useRecoveryProcess.ts
+++ b/packages/nextjs/hooks/flashbotRecoveryBundle/useRecoveryProcess.ts
@@ -269,7 +269,6 @@ export const useRecoveryProcess = () => {
     safeAddress: string;
     hackedAddress: string;
   }): RecoveryTx[] => {
-    console.log("DEBUG: generateCorrectTransactions", safeAddress);
     const result: RecoveryTx[] = [];
     for (const item of transactions) {
       let newTX: RecoveryTx = { ...item };
@@ -347,7 +346,6 @@ export const useRecoveryProcess = () => {
   }: IStartProcessProps & IChangeRPCProps) => {
     const isValid = validateBundleIsReady(safeAddress);
     if (!isValid) {
-      console.log("DEBUG: isValid", isValid); // gives false
       return;
     }
     //////// Enforce switching to flashbots RPC

--- a/packages/nextjs/hooks/flashbotRecoveryBundle/useRecoveryProcess.ts
+++ b/packages/nextjs/hooks/flashbotRecoveryBundle/useRecoveryProcess.ts
@@ -79,10 +79,8 @@ export const useRecoveryProcess = () => {
     if (!address) {
       setStepActive(RecoveryProcessStatus.NO_CONNECTED_ACCOUNT);
       return false;
-    } else if (address != safeAddress) {
-      setStepActive(RecoveryProcessStatus.NO_SAFE_ACCOUNT);
-      return false;
     }
+    // there was a piece of code RETURNING early if the safe address is not equal to the connected address
     return true;
   };
 
@@ -271,6 +269,7 @@ export const useRecoveryProcess = () => {
     safeAddress: string;
     hackedAddress: string;
   }): RecoveryTx[] => {
+    console.log("DEBUG: generateCorrectTransactions", safeAddress);
     const result: RecoveryTx[] = [];
     for (const item of transactions) {
       let newTX: RecoveryTx = { ...item };
@@ -348,6 +347,7 @@ export const useRecoveryProcess = () => {
   }: IStartProcessProps & IChangeRPCProps) => {
     const isValid = validateBundleIsReady(safeAddress);
     if (!isValid) {
+      console.log("DEBUG: isValid", isValid); // gives false
       return;
     }
     //////// Enforce switching to flashbots RPC

--- a/packages/nextjs/pages/index.tsx
+++ b/packages/nextjs/pages/index.tsx
@@ -64,7 +64,6 @@ const Home: NextPage = () => {
   } = useSendTransaction(config);
 
   const startSigning = (address: string) => {
-    console.log("DEBUG: startSigning", unsignedTxs);
     const transformedTransactions = generateCorrectTransactions({
       transactions: unsignedTxs,
       safeAddress: address,
@@ -74,17 +73,15 @@ const Home: NextPage = () => {
     signRecoveryTransactions(hackedAddress, unsignedTxs, currentBundleId, false);
   };
 
-  const startRecovery = (safe: string) => {
-    console.log("DEBUG: startRecovery", unsignedTxs);
-    setSafeAddress(safe);
+  const startRecovery = () => {
     const transformedTransactions = generateCorrectTransactions({
       transactions: unsignedTxs,
-      safeAddress: safe,
+      safeAddress,
       hackedAddress,
     });
     setUnsignedTxs(transformedTransactions);
     startRecoveryProcess({
-      safeAddress: safe,
+      safeAddress,
       hackedAddress,
       currentBundleId,
       transactions: transformedTransactions,
@@ -184,7 +181,7 @@ const Home: NextPage = () => {
           startSigning={address => startSigning(address)}
           totalGasEstimate={totalGasEstimate}
           showTipsModal={showTipsModal}
-          startProcess={add => startRecovery(add)}
+          startProcess={startRecovery}
           attemptedBlock={attemptedBlock}
           connectedAddress={connectedAddress}
           safeAddress={safeAddress}


### PR DESCRIPTION
### This PR:
-> Removes the check for secure address == connected address
-> Removes the parameter in startRecovery function, the function now uses the already existing safeAddress in the component





Fixes #58 